### PR TITLE
ci: migrate SBOM attestation to actions/attest

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -430,7 +430,7 @@ jobs:
             -o table
 
       - name: Attest
-        uses: actions/attest-sbom@v4
+        uses: actions/attest@v4
         id: attest
         with:
           subject-name: index.docker.io/${{ env.DOCKER_IMAGE_NAME }}


### PR DESCRIPTION
## What

Resolves the deprecation notice: **`actions/attest-sbom has been deprecated, please use actions/attest instead`**.

Swaps the SBOM "Attest" step in `pipeline.yml` from `actions/attest-sbom@v4` to `actions/attest@v4`.

## Why it's a safe drop-in

Per GitHub's docs, `actions/attest-sbom@v4` is now just a **wrapper over `actions/attest`**, and `actions/attest@v4` accepts the same **`sbom-path`** input directly (SPDX/CycloneDX JSON). So every input is unchanged:

```yaml
      - name: Attest
        uses: actions/attest@v4        # was actions/attest-sbom@v4
        id: attest
        with:
          subject-name: index.docker.io/${{ env.DOCKER_IMAGE_NAME }}
          subject-digest: ${{ needs.build_image.outputs.digest }}
          sbom-path: '/tmp/syft/sbom.spdx.json'
          push-to-registry: true
```

- Nothing references the step's outputs (`steps.attest.outputs.*`), so no downstream impact.
- YAML validated locally.

Sources: [actions/attest-sbom](https://github.com/actions/attest-sbom) (deprecation notice), [actions/attest](https://github.com/actions/attest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)