### PR TITLE
ci(dependabot): group npm, github-actions and docker updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,15 +6,27 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore'
+    groups:
+      npm-dependencies:
+        patterns:
+          - '*'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'daily'
     commit-message:
       prefix: 'ci'
+    groups:
+      github-actions:
+        patterns:
+          - '*'
   - package-ecosystem: 'docker'
     directory: '/'
     schedule:
       interval: 'daily'
     commit-message:
       prefix: 'build'
+    groups:
+      docker:
+        patterns:
+          - '*'


### PR DESCRIPTION
## What

Group Dependabot updates so daily bumps arrive as a **single PR per ecosystem** (npm, github-actions, docker) instead of one PR per dependency.

Adds a catch-all `groups` entry to each ecosystem; the existing `commit-message` prefixes (`chore`/`ci`/`build`) and the `daily` schedule are unchanged.

```yaml
    commit-message:
      prefix: 'chore'
+   groups:
+     npm-dependencies:
+       patterns:
+         - '*'
```

## Notes
- Grouped PRs still report an aggregated `update-type` via `fetch-metadata`, so any existing auto-merge logic is unaffected.
- Validated as well-formed YAML locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)