### PR TITLE
ci(dependabot): add grouped bundler ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,13 @@ updates:
       docker:
         patterns:
           - '*'
+  - package-ecosystem: 'bundler'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    commit-message:
+      prefix: 'chore'
+    groups:
+      bundler:
+        patterns:
+          - '*'


### PR DESCRIPTION
## What

Add a grouped `bundler` ecosystem so the root `Gemfile` gets automated dependency-update PRs — the last ecosystem not yet covered by Dependabot.

```yaml
  - package-ecosystem: 'bundler'
    directory: '/'
    schedule:
      interval: 'daily'
    commit-message:
      prefix: 'chore'
    groups:
      bundler:
        patterns:
          - '*'
```

Same catch-all grouping + daily schedule as the other ecosystems, with a `chore` prefix (matching npm's dependency-bump convention).

## Why

The Ruby/inspec advisories surfaced earlier (jwt, excon) get no automated bumps today because `bundler` wasn't tracked. This lets Dependabot raise the inspec/gem updates (grouped into a single daily PR) as fixes become available upstream.

Validated as well-formed YAML locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
