### PR TITLE
ci(dependabot): add 30-day major-version cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore'
+    cooldown:
+      semver-major-days: 30
     groups:
       npm-dependencies:
         patterns:
@@ -16,6 +18,8 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'ci'
+    cooldown:
+      semver-major-days: 30
     groups:
       github-actions:
         patterns:
@@ -26,6 +30,8 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'build'
+    cooldown:
+      semver-major-days: 30
     groups:
       docker:
         patterns:
@@ -36,6 +42,8 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore'
+    cooldown:
+      semver-major-days: 30
     groups:
       bundler:
         patterns:


### PR DESCRIPTION
## What

Add `cooldown.semver-major-days: 30` to every ecosystem (npm, github-actions, docker, bundler) in `dependabot.yml`.

```yaml
    cooldown:
      semver-major-days: 30
```

## Why

Dependabot holds a **major** bump back until the new version has been out for 30 days — a *delay*, not a permanent block. This gives the ecosystem time to catch up before a major lands, and directly unblocks the grouped npm PR (#790):

- `@babel/preset-env@8` / `@babel/eslint-parser@8` (21–22 days old) and `@pact-foundation/pact@17` (8 days old) are all < 30 days, so they're **excluded from the group** until they age past the window — leaving only the resolvable minor/patch bumps.
- Those Babel-8 / pact-17 majors currently can't resolve anyway (Stryker pins `@babel/core@7`; jest-pact pins pact `^16`). The cooldown buys ~1–3 weeks for those tools to ship compatible releases; if they do, the majors flow through automatically when the window lifts — if not, they reappear and we reassess.
- Also defers the `node 24→26` base-image bump (#716).

Non-permanent, self-managing, no manual cleanup. Validated as well-formed YAML.

> Note: branch name `dependabot-bundler` is a leftover — #789 (bundler) was merged and GitHub deleted the branch, so this cooldown commit re-created it. Happy to rename if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)