### PR TITLE
ci(dependabot): ignore Node major updates until LTS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,11 @@ updates:
       prefix: 'build'
     cooldown:
       semver-major-days: 30
+    ignore:
+      # Only upgrade Node on our terms (when the new even major reaches
+      # Active LTS); keep patch/minor updates on the current LTS line.
+      - dependency-name: 'node'
+        update-types: ['version-update:semver-major']
     groups:
       docker:
         patterns:


### PR DESCRIPTION
## What

Add an `ignore` rule to the **docker** ecosystem so Dependabot won't propose **Node major** bumps:

```yaml
    ignore:
      - dependency-name: 'node'
        update-types: ['version-update:semver-major']
```

## Why

Dependabot has no LTS awareness, and Node **even** majors ship as *Current* ~6 months before they reach **Active LTS** (e.g. Node 26 is out now but isn't LTS until ~October 2026). This rule means:

- **Node major jumps (24 → 26) are never auto-proposed** — supersedes the still-open #716.
- **24.x patch/minor updates keep flowing** (security fixes on the current LTS line still land).
- The major is bumped **manually** when the new even version reaches Active LTS — a deliberate step across the `Dockerfile`, the `engines` pin, and the inspec `node:24` assertion.

Sits on top of the existing 30-day major cooldown (merged in #791); the ignore is the stricter, Node-specific gate. Validated as well-formed YAML.

Once merged, **#716 can be closed** (it won't be re-proposed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)