### PR TITLE
chore(eslint): add complexity rule (warn, max 4)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,6 +34,7 @@ export default [
     },
     rules: {
       camelcase: 0,
+      complexity: ['warn', { max: 4 }],
       'jest/expect-expect': [
         'error',
         {


### PR DESCRIPTION
## What

Recreates the ESLint complexity configuration from the stale #639, cleanly off current `main`.

```js
      complexity: ['warn', { max: 4 }],
```

## Why a fresh PR

#639 was ~4 months / 270 commits behind `main`, its blocking `pact_test` red was an expired stale result, and its `.grype.yaml` hunk (a tar advisory ignore) is now obsolete — `main`'s grype policy was rewritten and no longer has a tar entry. This PR keeps only the still-valid piece: the complexity rule.

## Verification

- `npm run lint:verify` passes (exit 0). `complexity` is a **warning**, so it never fails the build.
- The current codebase produces **0 complexity warnings** — nothing to fix today; it guards future functions above cyclomatic complexity 4.

Once this is in, **#639 can be closed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)